### PR TITLE
fix: stabilize CI YAML and test environment compatibility

### DIFF
--- a/agent-sdk/pnpm-lock.yaml
+++ b/agent-sdk/pnpm-lock.yaml
@@ -1,0 +1,201 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@x402/core':
+        specifier: ^2.12.0
+        version: 2.12.0
+      '@x402/evm':
+        specifier: ^2.12.0
+        version: 2.12.0
+      '@x402/fetch':
+        specifier: ^2.12.0
+        version: 2.12.0
+      dotenv:
+        specifier: ^16.5.0
+        version: 16.6.1
+      viem:
+        specifier: ^2.30.0
+        version: 2.49.2(zod@3.25.76)
+
+packages:
+
+  '@adraffy/ens-normalize@1.11.1':
+    resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
+
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.9.1':
+    resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
+  '@scure/bip32@1.7.0':
+    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
+
+  '@scure/bip39@1.6.0':
+    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
+
+  '@x402/core@2.12.0':
+    resolution: {integrity: sha512-dLae9AbZRN/W7GsKe9ngqGsflnP+esE72s0GjmqDZbPihM/tlHCA6UnDdgM0qfOiDOf9iL+mmCs1OyLWpwnGLQ==}
+
+  '@x402/evm@2.12.0':
+    resolution: {integrity: sha512-kZUoHPVdBS8wlTg5K1eoh/1V0+5n9ABGRPC5DOQwRlkAwIrAFOEi2pQE+jgvOx0iM5ib2xj9gJjpldRbasX12w==}
+
+  '@x402/fetch@2.12.0':
+    resolution: {integrity: sha512-lkN/fzkZjnbJreLwI3fessKAaTKsOrrc0mFPGHWwZy0W/s8KFusLwdHuS8ul/XdUyNcYYrwcV6z0faGGSWNUNA==}
+
+  abitype@1.2.3:
+    resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3.22.0 || ^4.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
+  isows@1.0.7:
+    resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
+    peerDependencies:
+      ws: '*'
+
+  ox@0.14.20:
+    resolution: {integrity: sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  viem@2.49.2:
+    resolution: {integrity: sha512-nZQTExZDZfxdz2NZnl70t41Mb4/jENt3AkVsVcHO18Jkgcg1VytEpWxLkqp7OC1vW8a4h3CYZPfwnAq/E+gf4A==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@adraffy/ens-normalize@1.11.1': {}
+
+  '@noble/ciphers@1.3.0': {}
+
+  '@noble/curves@1.9.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@noble/hashes@1.8.0': {}
+
+  '@scure/base@1.2.6': {}
+
+  '@scure/bip32@1.7.0':
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
+  '@scure/bip39@1.6.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
+  '@x402/core@2.12.0':
+    dependencies:
+      zod: 3.25.76
+
+  '@x402/evm@2.12.0':
+    dependencies:
+      '@x402/core': 2.12.0
+      viem: 2.49.2(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  '@x402/fetch@2.12.0':
+    dependencies:
+      '@x402/core': 2.12.0
+
+  abitype@1.2.3(zod@3.25.76):
+    optionalDependencies:
+      zod: 3.25.76
+
+  dotenv@16.6.1: {}
+
+  eventemitter3@5.0.1: {}
+
+  isows@1.0.7(ws@8.18.3):
+    dependencies:
+      ws: 8.18.3
+
+  ox@0.14.20(zod@3.25.76):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(zod@3.25.76)
+      eventemitter3: 5.0.1
+    transitivePeerDependencies:
+      - zod
+
+  viem@2.49.2(zod@3.25.76):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(zod@3.25.76)
+      isows: 1.0.7(ws@8.18.3)
+      ox: 0.14.20(zod@3.25.76)
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  ws@8.18.3: {}
+
+  zod@3.25.76: {}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "pnpm exec eslint src next.config.ts eslint.config.mjs vitest.config.ts",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "node scripts/run-vitest.mjs",
     "format": "biome format --write . --files-ignore-unknown=true",
     "check:biome": "biome check . --files-ignore-unknown=true",
     "check:repo-safety": "node scripts/check-repo-safety.mjs",

--- a/scripts/run-vitest.mjs
+++ b/scripts/run-vitest.mjs
@@ -1,6 +1,6 @@
+import { spawn } from "node:child_process";
 import { mkdirSync } from "node:fs";
 import path from "node:path";
-import { spawn } from "node:child_process";
 
 const rootDir = process.cwd();
 const tempDir = path.join(rootDir, ".tmp", "vitest-tmp");

--- a/scripts/run-vitest.mjs
+++ b/scripts/run-vitest.mjs
@@ -1,0 +1,32 @@
+import { mkdirSync } from "node:fs";
+import path from "node:path";
+import { spawn } from "node:child_process";
+
+const rootDir = process.cwd();
+const tempDir = path.join(rootDir, ".tmp", "vitest-tmp");
+
+mkdirSync(tempDir, { recursive: true });
+
+const env = {
+  ...process.env,
+  TEMP: tempDir,
+  TMP: tempDir,
+  TMPDIR: tempDir,
+};
+
+const args = ["vitest", "run", ...process.argv.slice(2)];
+const child = spawn("pnpm", args, {
+  cwd: rootDir,
+  env,
+  stdio: "inherit",
+  shell: process.platform === "win32",
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 1);
+});

--- a/src/lib/infrastructure/store.ts
+++ b/src/lib/infrastructure/store.ts
@@ -17,7 +17,17 @@ import {
 } from "@/lib/infrastructure/postgres-store";
 
 const dataDir = path.join(process.cwd(), "data");
-const sqlitePath = path.join(dataDir, "mandate402.sqlite");
+const testDataDir = path.join(process.cwd(), ".tmp", "test-sqlite");
+
+function getSqlitePath() {
+  const workerId = process.env.VITEST_POOL_ID;
+  if (workerId) {
+    mkdirSync(testDataDir, { recursive: true });
+    return path.join(testDataDir, `mandate402-${workerId}.sqlite`);
+  }
+
+  return path.join(dataDir, "mandate402.sqlite");
+}
 
 const seedData: StoreData = {
   agents: [
@@ -131,7 +141,7 @@ function ensureDatabase() {
   }
 
   mkdirSync(dataDir, { recursive: true });
-  database = new DatabaseSync(sqlitePath);
+  database = new DatabaseSync(getSqlitePath());
   database.exec(`
     PRAGMA journal_mode = WAL;
     PRAGMA foreign_keys = ON;

--- a/src/lib/infrastructure/store.ts
+++ b/src/lib/infrastructure/store.ts
@@ -1,6 +1,6 @@
 import { mkdirSync } from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
-import { DatabaseSync } from "node:sqlite";
 
 import type { StoreData } from "@/lib/domain/types";
 import { nowIso } from "@/lib/infrastructure/clock";
@@ -18,6 +18,24 @@ import {
 
 const dataDir = path.join(process.cwd(), "data");
 const testDataDir = path.join(process.cwd(), ".tmp", "test-sqlite");
+const require = createRequire(import.meta.url);
+
+type SqliteDatabase = {
+  exec(sql: string): void;
+  prepare(sql: string): {
+    get(): unknown;
+    all(): unknown[];
+    run(...values: unknown[]): void;
+  };
+};
+
+let sqliteDatabaseSyncCtor:
+  | (new (
+      path: string,
+    ) => SqliteDatabase)
+  | null
+  | undefined;
+let memoryStoreData: StoreData | null = null;
 
 function getSqlitePath() {
   const workerId = process.env.VITEST_POOL_ID;
@@ -27,6 +45,23 @@ function getSqlitePath() {
   }
 
   return path.join(dataDir, "mandate402.sqlite");
+}
+
+function getSqliteDatabaseSyncCtor() {
+  if (sqliteDatabaseSyncCtor !== undefined) {
+    return sqliteDatabaseSyncCtor;
+  }
+
+  try {
+    const module = require("node:sqlite") as {
+      DatabaseSync: new (path: string) => SqliteDatabase;
+    };
+    sqliteDatabaseSyncCtor = module.DatabaseSync;
+  } catch {
+    sqliteDatabaseSyncCtor = null;
+  }
+
+  return sqliteDatabaseSyncCtor;
 }
 
 const seedData: StoreData = {
@@ -117,7 +152,7 @@ const seedData: StoreData = {
 };
 
 let lock = Promise.resolve();
-let database: DatabaseSync | null = null;
+let database: SqliteDatabase | null = null;
 
 function ensureDatabase() {
   const persistenceMode = getPersistenceMode();
@@ -140,8 +175,13 @@ function ensureDatabase() {
     return database;
   }
 
+  const DatabaseSyncCtor = getSqliteDatabaseSyncCtor();
+  if (!DatabaseSyncCtor) {
+    return null;
+  }
+
   mkdirSync(dataDir, { recursive: true });
-  database = new DatabaseSync(getSqlitePath());
+  database = new DatabaseSyncCtor(getSqlitePath());
   database.exec(`
     PRAGMA journal_mode = WAL;
     PRAGMA foreign_keys = ON;
@@ -229,6 +269,11 @@ function ensureDatabase() {
 
 function writeStoreSync(data: StoreData) {
   const db = ensureDatabase();
+  if (!db) {
+    memoryStoreData = storeDataClone(data);
+    return;
+  }
+
   const store = storeDataClone(data);
   db.exec("BEGIN");
   try {
@@ -365,6 +410,13 @@ export async function readStore(): Promise<StoreData> {
   }
 
   const db = ensureDatabase();
+  if (!db) {
+    if (!memoryStoreData) {
+      memoryStoreData = createSeedStoreData();
+    }
+
+    return storeDataClone(memoryStoreData);
+  }
 
   const agents = db
     .prepare(`
@@ -543,4 +595,5 @@ export async function withStoreLock<T>(work: (data: StoreData) => Promise<T>) {
 export async function resetPersistenceForTests() {
   await resetPostgresStoreForTests();
   database = null;
+  memoryStoreData = null;
 }

--- a/src/lib/infrastructure/store.ts
+++ b/src/lib/infrastructure/store.ts
@@ -53,10 +53,10 @@ function getSqliteDatabaseSyncCtor() {
   }
 
   try {
-    const module = require("node:sqlite") as {
+    const sqliteModule = require("node:sqlite") as {
       DatabaseSync: new (path: string) => SqliteDatabase;
     };
-    sqliteDatabaseSyncCtor = module.DatabaseSync;
+    sqliteDatabaseSyncCtor = sqliteModule.DatabaseSync;
   } catch {
     sqliteDatabaseSyncCtor = null;
   }

--- a/team-structure.yml
+++ b/team-structure.yml
@@ -1,3 +1,4 @@
+---
 version: "0.1.0"
 project: "Mandate402"
 organization: "Core Dev Squad"
@@ -5,7 +6,8 @@ roles:
   - member: "Justine"
     github: "JustineDevs"
     title: "Full Stack & Project Manager"
-    domain: "Product Direction, Infrastructure, Sprint Management, Socials"
+    domain: >-
+      Product Direction, Infrastructure, Sprint Management, Socials
     responsibilities:
       - "Define sprint goals and product roadmaps"
       - "Manage cloud infrastructure and deployments"
@@ -19,28 +21,42 @@ roles:
     responsibilities:
       - "Create high-fidelity wireframes and user flows"
       - "Maintain design system and UI consistency"
-      - "Hand off visual assets and layout intent to frontend engineering"
+      - >-
+        Hand off visual assets and layout intent to frontend engineering
 
   - member: "Edward Joseph"
     github: "automatewithedward"
     title: "Frontend Developer - Transactional UI"
-    domain: "Stateful UI, API Integration, Action Flows"
+    domain: >-
+      Stateful UI, API Integration, Action Flows
     responsibilities:
       - "Clone or sync the repository and audit existing architecture"
-      - "Implement mandate creation, attempt, revoke, and auth-aware frontend flows"
-      - "Own API-connected and stateful UI behavior without widening runtime semantics"
+      - >-
+        Implement mandate creation, attempt, revoke, and auth-aware frontend
+        flows
+      - >-
+        Own API-connected and stateful UI behavior without widening runtime
+        semantics
 
   - member: "John Abrahm"
     github: "bam841"
     title: "Frontend Developer - Observability UI"
-    domain: "Dashboard, Audit Views, Presentation Components"
+    domain: >-
+      Dashboard, Audit Views, Presentation Components
     responsibilities:
       - "Implement dashboard, audit, receipt, and status surfaces"
-      - "Own reusable presentation components and responsive refinement in read-heavy surfaces"
-      - "Preserve shared design primitives instead of duplicating component systems"
+      - >-
+        Own reusable presentation components and responsive refinement in
+        read-heavy surfaces
+      - >-
+        Preserve shared design primitives instead of duplicating component
+        systems
 
 interaction_workflow:
   step_1: "Justine defines sprint goal and feature scope."
   step_2: "Sherwin designs the wireframe layout based on scope."
-  step_3: "Justine reviews design for technical and product alignment."
-  step_4: "Edward Joseph and John Abrahm implement separate frontend lanes from one shared design source."
+  step_3: >-
+    Justine reviews design for technical and product alignment.
+  step_4: >-
+    Edward Joseph and John Abrahm implement separate frontend lanes from one
+    shared design source.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ const rootDir = path.dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
   test: {
     environment: "node",
+    cacheDir: path.join(rootDir, ".tmp", "vitest-cache"),
   },
   resolve: {
     alias: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,9 +6,9 @@ import { defineConfig } from "vitest/config";
 const rootDir = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
+  cacheDir: path.join(rootDir, ".tmp", "vitest-cache"),
   test: {
     environment: "node",
-    cacheDir: path.join(rootDir, ".tmp", "vitest-cache"),
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Problem
Two CI failures were blocking progress:

1. `Validate Team Config (v0.1.0)` failed because `team-structure.yml` violated YAML lint rules.
2. `CI / app` failed because the test environment depended on runtime-specific behavior:
   - SQLite-backed tests could contend on shared DB files in parallel environments.
   - Environments without `node:sqlite` could crash at module load.
   - Cursor/GUI temp-path behavior could leak unsafe temp/cache paths into Vitest.

## What Changed

### YAML / workflow config
- made `team-structure.yml` YAML-lint safe without changing the schema
- added document start marker and folded long strings instead of inventing continuation keys

### Test environment compatibility
- kept Vitest temp/cache paths repo-local via the wrapper and config already introduced
- made the demo-mode store tolerate environments where `node:sqlite` is unavailable by falling back to an in-memory store instead of crashing at module load
- preserved production fail-closed behavior; this compatibility path is only for demo/test-mode environments
- kept per-worker SQLite path isolation for test runs

## Verification
- local YAML parse for `team-structure.yml` passed
- `git diff --check` passed for the touched files
- branch pushed cleanly for CI verification

## Scope
This PR is intentionally narrow:
- `team-structure.yml`
- `src/lib/infrastructure/store.ts`
- test-runner environment compatibility already present in the branch history

## Notes
This PR is about CI/runtime-environment stability, not product behavior or production auth/store semantics.