### PR TITLE
Remove redundant repository badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
   <p><strong>The autonomous governance and treasury command center for x402 machine commerce on Morph.</strong></p>
 
   <p>
-    <a href="https://github.com/JustineDevs/mandate402"><img alt="Repository" src="https://img.shields.io/badge/GitHub-JustineDevs%2Fmandate402-181717?logo=github" /></a>
     <img alt="License" src="https://img.shields.io/badge/license-MIT-22c55e" />
     <img alt="Next.js" src="https://img.shields.io/badge/Next.js-15-black?logo=next.js" />
     <img alt="Foundry" src="https://img.shields.io/badge/Foundry-Solidity-orange" />


### PR DESCRIPTION
## Problem
The README header included a repository self-link badge, which duplicates the current GitHub page context and adds noise to the badge group.

Closes #12.

## What Changed
- Removed the GitHub repository self-link badge from the root README.
- Kept the DeepWiki badge and the remaining project badges intact.

## Verification
- git diff --check origin/main...HEAD
- Confirmed PR diff is one commit touching only README.md.

## Deployment / Credentials
No deployment or credential changes.

## Remaining Blockers
None.

## Owner Lane
Justine / documentation hygiene.

## AI Usage
AI-assisted README cleanup, issue creation, and PR preparation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/justinedevs/mandate402/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->