### PR TITLE
Introduce a development integration branch

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -1,6 +1,6 @@
 # Branch Protection Recommendations
 
-Recommended protection for `main` on `JustineDevs/mandate402`:
+Recommended protection for `main` and `development` on `JustineDevs/mandate402`:
 
 ## Required status checks
 
@@ -24,6 +24,10 @@ Recommended protection for `main` on `JustineDevs/mandate402`:
 - Restrict direct pushes to maintainers only
 - Prefer squash merge only
 
+Apply the same protection baseline to `development`, with one extra expectation:
+
+- allow the repo-maintained sync workflow or designated maintainer automation to keep `development` current with `main`
+
 ## Team workflow alignment
 
 For the `v0.1.0` team process:
@@ -39,3 +43,4 @@ For the `v0.1.0` team process:
 - Create a Changeset for user-visible repo changes
 - Use semantic-release from `main` only
 - Treat `main` as the only branch allowed to produce release tags and notes
+- Treat `development` as the integration branch for team PRs, not a release branch

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,13 +7,13 @@
 /docs/adr/ADR-0002-sherwin-ui-wireframe-task.md @owenlim225 @JustineDevs
 
 # Transactional frontend
-/src/components/operator-console.tsx @automatewithedward @JustineDevs
-/src/app/api/mandates/** @automatewithedward @JustineDevs
-/docs/adr/ADR-0003-edward-frontend-implementation-task.md @automatewithedward @JustineDevs
+/src/components/operator-console.tsx @bam841 @JustineDevs
+/src/app/api/mandates/** @bam841 @JustineDevs
+/docs/adr/ADR-0003-john-frontend-implementation-task.md @bam841 @JustineDevs
 
 # Observability / presentation frontend
-/src/components/dashboard.tsx @bam841 @JustineDevs
-/src/components/header-hero.tsx @bam841 @owenlim225 @JustineDevs
+/src/components/dashboard.tsx @automatewithedward @JustineDevs
+/src/components/header-hero.tsx @automatewithedward @owenlim225 @JustineDevs
 
 # Governance / process
 /docs/TEAM.md @JustineDevs

--- a/.github/ISSUE_TEMPLATE/feature_handoff.md
+++ b/.github/ISSUE_TEMPLATE/feature_handoff.md
@@ -20,7 +20,7 @@ assignees: []
 
 ## Phase 3: Frontend Implementation
 
-### Transactional UI (Edward Joseph `@automatewithedward`)
+### Transactional UI (John Abrahm `@bam841`)
 
 ### Repository Intake Checklist
 
@@ -33,7 +33,7 @@ assignees: []
 - [ ] Implement mandate/action/auth-aware UI flows.
 - [ ] Connect API endpoints or safe placeholder data as required.
 
-### Observability UI (John Abrahm `@bam841`)
+### Observability UI (Edward Joseph `@automatewithedward`)
 
 - [ ] Implement dashboard, audit, receipt, and status surfaces.
 - [ ] Reuse shared primitives instead of duplicating component systems.
@@ -42,6 +42,6 @@ assignees: []
 ## Phase 4: Sign-Off Criteria
 
 - Sherwin: UI matches the visual design intent.
-- Edward: Transactional UI is interactive and does not break existing behavior.
-- John: Observability UI is consistent, responsive, and aligned to the shared design system.
+- John: Transactional UI is interactive and does not break existing behavior.
+- Edward: Observability UI is consistent, responsive, and aligned to the shared design system.
 - Justine: Code is reviewed, infrastructure is stable, and the PR is ready to merge.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@
 ### Repository Audit & Implementation Notes
 
 - [ ] I synced and built the repository locally.
-- [ ] I synced/rebased from latest `main` before requesting review.
+- [ ] I synced/rebased from latest `development` before requesting review.
 - [ ] I audited the existing code structure before making changes.
 - [ ] I stayed within my frontend lane ownership or documented any cross-lane edits.
 

--- a/.github/workflows/api-smoke.yml
+++ b/.github/workflows/api-smoke.yml
@@ -2,7 +2,7 @@ name: API Smoke
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "development"]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: ["main", "development"]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   app:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "development"]
   pull_request:
 
 jobs:

--- a/.github/workflows/pr-routing.yml
+++ b/.github/workflows/pr-routing.yml
@@ -1,0 +1,67 @@
+name: PR Routing
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  route-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pull_number = context.payload.pull_request.number;
+            const author = context.payload.pull_request.user.login;
+
+            const reviewerAllowlist = ["JustineDevs", "devin-ai-integration"];
+            const desiredReviewers = reviewerAllowlist.filter((login) => login !== author);
+
+            const { data: pull } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number,
+            });
+
+            const currentReviewers = pull.requested_reviewers.map((reviewer) => reviewer.login);
+            const reviewersToRemove = currentReviewers.filter(
+              (login) => !desiredReviewers.includes(login),
+            );
+            const reviewersToAdd = desiredReviewers.filter(
+              (login) => !currentReviewers.includes(login),
+            );
+
+            if (reviewersToRemove.length > 0) {
+              await github.rest.pulls.removeRequestedReviewers({
+                owner,
+                repo,
+                pull_number,
+                reviewers: reviewersToRemove,
+              });
+            }
+
+            if (reviewersToAdd.length > 0) {
+              await github.rest.pulls.requestReviewers({
+                owner,
+                repo,
+                pull_number,
+                reviewers: reviewersToAdd,
+              });
+            }
+
+            await github.rest.issues.setAssignees({
+              owner,
+              repo,
+              issue_number: pull_number,
+              assignees: ["JustineDevs"],
+            });

--- a/.github/workflows/sync-development.yml
+++ b/.github/workflows/sync-development.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Trigger development verification workflows
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
         run: |
           gh workflow run ci.yml --ref development
           gh workflow run api-smoke.yml --ref development

--- a/.github/workflows/sync-development.yml
+++ b/.github/workflows/sync-development.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
 
 concurrency:
@@ -54,3 +55,10 @@ jobs:
           fi
 
           git push origin HEAD:development
+
+      - name: Trigger development verification workflows
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run ci.yml --ref development
+          gh workflow run api-smoke.yml --ref development

--- a/.github/workflows/sync-development.yml
+++ b/.github/workflows/sync-development.yml
@@ -1,0 +1,56 @@
+name: Sync Development
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-development
+  cancel-in-progress: false
+
+jobs:
+  sync-development:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Ensure development exists
+        run: |
+          git fetch origin main development || true
+          if git show-ref --verify --quiet refs/remotes/origin/development; then
+            echo "development already exists"
+            exit 0
+          fi
+
+          git branch development origin/main
+          git push origin development:development
+
+      - name: Merge main into development
+        run: |
+          git fetch origin main development
+          git switch -c development-sync origin/development
+          before_sha="$(git rev-parse HEAD)"
+
+          if ! git merge --no-edit origin/main; then
+            echo "::error::Automatic sync from main into development hit a merge conflict. Resolve it manually before the branch drifts further."
+            exit 1
+          fi
+
+          after_sha="$(git rev-parse HEAD)"
+          if [ "$before_sha" = "$after_sha" ]; then
+            echo "development is already up to date with main"
+            exit 0
+          fi
+
+          git push origin HEAD:development

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,7 @@ Every meaningful issue must define:
 ### Branch and Worktree Rule
 
 - Do not work directly on `main`.
+- Do not work directly on `development`.
 - One issue must map to one branch.
 - One branch should map to one worktree when parallel work is active.
 - Do not stack unrelated work in one branch.
@@ -160,23 +161,26 @@ Recommended branch forms:
 
 ### Sync Rule
 
-All implementers must keep their ownership branch current with `main`.
+`main` remains the release-authoritative branch.
+`development` is the protected integration branch for normal team work.
+
+All implementers must keep their ownership branch current with `development`.
 
 Required sync moments:
 
 - before starting work for the day
 - before opening a PR
-- after `main` changes in a related lane
+- after `development` changes in a related lane
 - after a branch sits stale during active work
 
 Use:
 
 ```bash
 git fetch origin
-git switch main
-git pull --ff-only origin main
+git switch development
+git pull --ff-only origin development
 git switch <branch>
-git rebase origin/main
+git rebase origin/development
 ```
 
 Avoid implicit merge-commit syncs from plain `git pull` on feature branches.
@@ -225,7 +229,8 @@ without explicit authority from the tracked scope documents.
 - `main` is the only release-authoritative branch.
 - Release tags and release notes are automation-owned artifacts from `main`.
 - Every meaningful change must originate from its own ownership branch and land through PR.
-- Branches must be synced from latest `main` before final review unless Justine explicitly waives that requirement.
+- Ownership branches must be synced from latest `development` before final review unless Justine explicitly waives that requirement.
+- Promotion from `development` to `main` is the normal path to release-authoritative history.
 
 ### Before Commit
 
@@ -281,6 +286,16 @@ No merge to `main` unless all required checks are green.
 ## Branch Protection
 
 For `main`, maintain:
+
+- PR required before merge
+- at least 1 approval
+- stale approvals dismissed on new commits
+- required status checks
+- no force-push for non-maintainers
+- no direct merge with failing CI
+- squash merge by default
+
+For `development`, maintain:
 
 - PR required before merge
 - at least 1 approval

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,8 +190,8 @@ Avoid implicit merge-commit syncs from plain `git pull` on feature branches.
 Frontend ownership is intentionally split:
 
 - Sherwin = design authority
-- Edward = transactional frontend
-- John = observability / presentation frontend
+- John = transactional frontend
+- Edward = observability / presentation frontend
 - Justine = final integration / release authority
 
 Edward and John must not silently co-own the same screen or feature surface by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to this project will be documented in this file.
   - `docs/TEAM.md`
   - `docs/adr/ADR-0001-justine-scope-documents.md`
   - `docs/adr/ADR-0002-sherwin-ui-wireframe-task.md`
-  - `docs/adr/ADR-0003-edward-frontend-implementation-task.md`
+  - `docs/adr/ADR-0003-john-frontend-implementation-task.md`
   - `docs/adr/README.md`
   - `team-structure.yml`
   - `agentic-workflow.yml`
@@ -43,7 +43,7 @@ All notable changes to this project will be documented in this file.
 - expanded the team operating model to make Justine the integration/release hub, Sherwin the design handoff owner, and the frontend lane explicitly owned through separate transactional and observability implementers
 - formalized a linear workflow to prevent silo mentality, hyper-specialization, tunnel vision, and "us vs. them" collaboration failures
 - added an audience map, ADR index, glossary, status page, and design-token reference so the docs set can be used as a coherent documentation system instead of isolated files
-- split frontend ownership into two lanes: Edward for transactional UI and John Abrahm (`@bam841`) for observability/presentation UI
+- split frontend ownership into two lanes: John Abrahm (`@bam841`) for transactional UI and Edward Joseph (`@automatewithedward`) for observability/presentation UI
 
 ## 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ Mandate402 is a Morph-native governance and treasury control layer for x402 comm
 |---|---|---|---|
 | Justine | `@JustineDevs` | Project Manager / Full Stack | Product direction, infra, sprint, release, socials |
 | Sherwin | `@owenlim225` | UI/UX Designer | Wireframes, user experience, design system |
-| Edward Joseph | `@automatewithedward` | Frontend - Transactional UI | Mandate flows, auth-aware UI, API-connected interactions |
-| John Abrahm | `@bam841` | Frontend - Observability UI | Dashboard, audit, receipts, read-heavy UI, shared presentation |
+| John Abrahm | `@bam841` | Frontend - Transactional UI | Mandate flows, auth-aware UI, API-connected interactions |
+| Edward Joseph | `@automatewithedward` | Frontend - Observability UI | Dashboard, audit, receipts, read-heavy UI, shared presentation |
 
 Operational pipeline:
 
-`Justine (Scope)` -> `Sherwin (Wireframe)` -> `Justine (Review)` -> `Edward (Transactional UI) + John (Observability UI)` -> `Justine (Review & Merge)`
+`Justine (Scope)` -> `Sherwin (Wireframe)` -> `Justine (Review)` -> `John (Transactional UI) + Edward (Observability UI)` -> `Justine (Review & Merge)`
 
 These workflow, ownership, PR, and release rules are mandatory, not optional.
 
@@ -122,7 +122,7 @@ Mandate402 inserts a programmable policy boundary before x402 settlement:
 | [docs/TEAM.md](./docs/TEAM.md) | Team ownership model and anti-silo collaboration rules |
 | [docs/adr/ADR-0001-justine-scope-documents.md](./docs/adr/ADR-0001-justine-scope-documents.md) | Defines the explicit scope-authority surface for Justine-led tasks |
 | [docs/adr/ADR-0002-sherwin-ui-wireframe-task.md](./docs/adr/ADR-0002-sherwin-ui-wireframe-task.md) | Defines the canonical wireframe and design brief for Sherwin's task |
-| [docs/adr/ADR-0003-edward-frontend-implementation-task.md](./docs/adr/ADR-0003-edward-frontend-implementation-task.md) | Defines Edward's repo-audit-first implementation boundary |
+| [docs/adr/ADR-0003-john-frontend-implementation-task.md](./docs/adr/ADR-0003-john-frontend-implementation-task.md) | Defines John's repo-audit-first transactional implementation boundary |
 
 </details>
 

--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -4,9 +4,15 @@ This document defines the required Git branching model for Mandate402.
 
 ## Branch Model
 
-- `main` is the only protected integration branch.
-- All work must happen on short-lived feature/fix/docs/chore branches.
+- `main` is the only release-authoritative branch.
+- `development` is the protected team integration branch.
+- All day-to-day work must happen on short-lived feature/fix/docs/chore branches created from `development`.
 - Do not commit directly to `main`.
+- Do not commit directly to `development`.
+
+Normal path:
+
+`main` -> auto-sync into `development` -> ownership branch -> PR into `development` -> promotion PR from `development` into `main`
 
 ## Branch Naming
 
@@ -41,7 +47,8 @@ Do not rely on blind `git pull` on feature branches.
 Required strategy:
 
 - use `git pull --ff-only origin main` on `main`
-- use `git fetch origin` + `git rebase origin/main` on ownership branches
+- use `git pull --ff-only origin development` on `development`
+- use `git fetch origin` + `git rebase origin/development` on ownership branches
 
 Avoid by default:
 
@@ -53,16 +60,19 @@ because it may create implicit merge commits depending on local config.
 
 ## Branch Freshness Rule
 
-- A PR branch must be reasonably fresh against `main` before final review.
-- If `main` changed in a shared or related surface, the branch owner must sync before continuing implementation.
-- Branches behind `main` should be rebased before merge unless Justine explicitly approves review on a stale branch.
+- A team PR branch must be reasonably fresh against `development` before final review.
+- If `development` changed in a shared or related surface, the branch owner must sync before continuing implementation.
+- Branches behind `development` should be rebased before merge unless Justine explicitly approves review on a stale branch.
+- The `development` branch should stay current with `main` through the repo sync workflow or an explicit maintainer repair merge.
 
 ## Merge Rule
 
 - No direct pushes to `main`
+- No direct pushes to `development`
 - No merge without PR
 - No merge without passing required checks
 - No merge without Justine review on protected lanes
 - Use squash merge by default
 - Every ownership branch must map to one issue
-- Every merged branch must be releasable only through `main`
+- Team ownership branches normally merge into `development`
+- Releases and release tags still happen only through `main`

--- a/docs/FIRST-PR.md
+++ b/docs/FIRST-PR.md
@@ -31,7 +31,7 @@ Your first PR should be:
 
 ## Before Opening the PR
 
-- sync from latest `main`
+- sync from latest `development`
 - rerun the relevant checks
 - confirm your branch still matches the issue scope
 - mention any assumptions or blockers clearly

--- a/docs/FRONTEND-PRIMITIVES.md
+++ b/docs/FRONTEND-PRIMITIVES.md
@@ -1,6 +1,6 @@
 # Frontend Primitives
 
-This document defines the shared frontend primitives that Edward and John must reuse instead of duplicating.
+This document defines the shared frontend primitives that John and Edward must reuse instead of duplicating.
 
 ## Shared Primitive Classes
 
@@ -19,8 +19,8 @@ If a new frontend need can be satisfied by extending a shared primitive, do that
 
 ## Lane Reminder
 
-- Edward owns transactional UI
-- John owns observability/presentation UI
+- John owns transactional UI
+- Edward owns observability/presentation UI
 
 But neither lane owns a private duplicate primitive system.
 

--- a/docs/LANES.md
+++ b/docs/LANES.md
@@ -19,7 +19,7 @@ This document defines the required ownership map for Mandate402.
 - interaction intent
 - design authority
 
-### Edward
+### John
 
 - transactional frontend
 - auth-aware UI
@@ -33,7 +33,7 @@ Examples:
 - revoke flows
 - authenticated operator actions
 
-### John
+### Edward
 
 - observability frontend
 - dashboard

--- a/docs/RELEASE-POLICY.md
+++ b/docs/RELEASE-POLICY.md
@@ -28,10 +28,15 @@ Every change that affects the shipped product must:
 
 1. originate from its own ownership branch
 2. be linked to an issue
-3. land through a PR
+3. normally merge into `development` first
 4. pass required checks
-5. be merged into `main`
+5. be promoted from `development` into `main`
 6. allow release automation to decide whether a release is produced
+
+Hotfix exception:
+
+- urgent maintainer-approved hotfixes may branch from `main` and return directly to `main`
+- after a hotfix lands, `development` must be resynced from `main`
 
 ## Required Conditions Before Merge To `main`
 

--- a/docs/REPO-INGESTION.md
+++ b/docs/REPO-INGESTION.md
@@ -19,7 +19,7 @@ This document is for any human or AI contributor who needs a deterministic start
    - out of scope
 10. Identify the directories you may edit.
 11. Identify the directories you must not edit.
-12. Sync from latest `main`.
+12. Sync from latest `development`.
 
 ## Must Confirm Before Coding
 
@@ -34,5 +34,5 @@ This document is for any human or AI contributor who needs a deterministic start
 - issue review
 - lane confirmation
 - branch creation
-- sync from `main`
+- sync from `development`
 - review of shared primitives before creating new ones

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -48,7 +48,7 @@ It proves the control model first:
 
 - Justine scope authority is defined in [ADR-0001](./adr/ADR-0001-justine-scope-documents.md)
 - Sherwin's wireframe task is defined in [ADR-0002](./adr/ADR-0002-sherwin-ui-wireframe-task.md)
-- Edward's implementation boundary is defined in [ADR-0003](./adr/ADR-0003-edward-frontend-implementation-task.md)
+- John's transactional implementation boundary is defined in [ADR-0003](./adr/ADR-0003-john-frontend-implementation-task.md)
 - The frontend is split into transactional UI and observability/presentation UI lanes.
 
 ## Current Documentation State

--- a/docs/TEAM.md
+++ b/docs/TEAM.md
@@ -47,21 +47,6 @@ Core responsibilities:
 
 Scope:
 
-- transactional frontend implementation
-- client-side behavior for action-heavy surfaces
-- API-safe UI integration
-
-Core responsibilities:
-
-- clone and audit the repository before implementing UI work
-- implement mandate creation, attempt, revoke, and auth-aware UI flows
-- preserve runtime, API, and policy semantics while improving action-heavy UI
-- raise structural conflicts early instead of coding around them silently
-
-### John Abrahm (`@bam841`) - Frontend Developer
-
-Scope:
-
 - dashboard and read-heavy frontend implementation
 - reusable presentation components
 - responsive refinement for observability surfaces
@@ -72,6 +57,21 @@ Core responsibilities:
 - own read-model and presentation-heavy UI lanes
 - reuse shared primitives instead of duplicating frontend component systems
 - raise cross-lane collisions early when presentation changes affect transactional UI
+
+### John Abrahm (`@bam841`) - Frontend Developer
+
+Scope:
+
+- transactional frontend implementation
+- client-side behavior for action-heavy surfaces
+- API-safe UI integration
+
+Core responsibilities:
+
+- clone and audit the repository before implementing UI work
+- implement mandate creation, attempt, revoke, and auth-aware UI flows
+- preserve runtime, API, and policy semantics while improving action-heavy UI
+- raise structural conflicts early instead of coding around them silently
 
 ## Anti-Silo Contract
 
@@ -108,27 +108,27 @@ Sherwin does not own:
 - backend or API behavior
 - release truth
 
-### Edward owns
+### John owns
 
 - translating approved wireframes into transactional frontend flows
 - semantic HTML and component structure for action-heavy screens
 - frontend state and interaction wiring
 - auth-aware and API-connected UI behavior
 
-Edward does not own:
+John does not own:
 
 - silent changes to policy/runtime semantics
 - silent infra changes
 - bypassing product review because a UI is already coded
 
-### John owns
+### Edward owns
 
 - dashboard and read-heavy frontend surfaces
 - audit, receipts, and status views
 - reusable presentation components
 - responsive refinement for visibility-oriented screens
 
-John does not own:
+Edward does not own:
 
 - silent changes to transactional/API semantics
 - ad hoc duplication of shared primitives
@@ -150,7 +150,7 @@ For the explicit definition of what counts as Justine scope authority, see [ADR-
 
 All work should follow this handoff sequence:
 
-`Justine (Scope)` -> `Sherwin (Wireframe)` -> `Justine (Review)` -> `Edward (Transactional UI) + John (Observability UI)` -> `Justine (Review & Merge)`
+`Justine (Scope)` -> `Sherwin (Wireframe)` -> `Justine (Review)` -> `John (Transactional UI) + Edward (Observability UI)` -> `Justine (Review & Merge)`
 
 ### Phase 1: Scope
 
@@ -187,7 +187,7 @@ Output:
 
 ### Phase 4: Repo Intake and Implementation
 
-Owned by Edward and John in separate frontend lanes.
+Owned by John and Edward in separate frontend lanes.
 
 Output:
 
@@ -213,8 +213,7 @@ The frontend should not be treated as one undifferentiated lane.
 
 ### Frontend Lane A: Transactional UI
 
-Owner: Edward
-
+Owner: John
 Examples:
 
 - create mandate
@@ -225,7 +224,7 @@ Examples:
 
 ### Frontend Lane B: Observability UI
 
-Owner: John
+Owner: Edward
 
 Examples:
 
@@ -274,9 +273,9 @@ Operational rule:
 - design should feel precise, high-trust, and operational
 - design should not drift into generic SaaS polish, consumer-fintech softness, or crypto-casino styling
 
-## Edward Implementation Contract
+## John Implementation Contract
 
-Edward's task is not just to "code the UI." The expected sequence is:
+John's task is not just to "code the UI." The expected sequence is:
 
 1. clone or sync the latest repository state
 2. build and run the project locally
@@ -286,15 +285,15 @@ Edward's task is not just to "code the UI." The expected sequence is:
 6. preserve existing runtime and API semantics
 7. surface any architectural conflict before opening the PR
 
-Edward must not:
+John must not:
 
 - silently re-interpret the product scope
 - silently override design intent
 - silently change infra-facing config or runtime semantics
 
-## John Implementation Contract
+## Edward Implementation Contract
 
-John's task is to implement the presentation-heavy and read-model frontend lane without overlapping Edward's default action-heavy ownership.
+Edward's task is to implement the presentation-heavy and read-model frontend lane without overlapping John's default action-heavy ownership.
 
 The expected sequence is:
 
@@ -303,9 +302,9 @@ The expected sequence is:
 3. identify the read-heavy screens and shared primitives in scope
 4. implement dashboard, audit, receipt, and observability surfaces
 5. preserve shared component consistency across the frontend
-6. surface any overlap with Edward's lane before editing the same screen
+6. surface any overlap with John's lane before editing the same screen
 
-John must not:
+Edward must not:
 
 - silently take ownership of transactional flows
 - create duplicate primitive systems for cards, badges, tables, or status components

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -6,7 +6,7 @@ This document defines the required execution flow for all meaningful work in Man
 
 Every material change must move through this sequence:
 
-`Issue -> Scope -> Design or Technical Clarification -> Branch -> Implementation -> PR -> Review -> CI -> Merge`
+`Issue -> Scope -> Design or Technical Clarification -> Branch from development -> PR to development -> Review -> CI -> Merge -> Promotion PR to main`
 
 No meaningful work should skip the issue or PR stage.
 
@@ -32,12 +32,12 @@ No meaningful work should skip the issue or PR stage.
 
 Every contributor should start with:
 
-1. sync latest `main`
+1. sync latest `development`
 2. read [AGENTS.md](../AGENTS.md)
 3. read [WORKFLOW.md](./WORKFLOW.md), [BRANCHING.md](./BRANCHING.md), and [LANES.md](./LANES.md)
 4. open the linked issue
 5. confirm lane ownership and out-of-scope
-6. create a branch from the issue
+6. create a branch from `development` for the issue
 
 ## Example Issues
 
@@ -58,13 +58,13 @@ Every contributor should start with:
 
 ## Mandatory Sync Rule
 
-Every implementer must sync from the latest `main` before meaningful work continues.
+Every implementer must sync from the latest `development` before meaningful work continues.
 
 Required sync moments:
 
 1. before starting work for the day
 2. before opening a PR
-3. after `main` changes in a related lane
+3. after `development` changes in a related lane
 4. after a branch sits stale during active work
 
 Recommended stale thresholds:
@@ -82,29 +82,38 @@ git switch main
 git pull --ff-only origin main
 ```
 
+For `development`:
+
+```bash
+git fetch origin
+git switch development
+git pull --ff-only origin development
+```
+
 For an ownership branch:
 
 ```bash
 git fetch origin
 git switch <branch>
-git rebase origin/main
+git rebase origin/development
 ```
 
 ## Sync Verification Rule
 
-After rebasing or syncing from `main`, rerun the relevant checks before requesting review.
+After rebasing or syncing from `development`, rerun the relevant checks before requesting review.
 
 ## Non-Negotiable Rules
 
 - No direct work on `main`.
+- No direct work on `development`.
 - No meaningful implementation without an issue.
 - No PR without a linked issue.
 - No frontend implementation without Sherwin handoff when visual changes are involved.
 - No AI-generated infra, auth, contract, or release change merges without human review.
 - No merge while CI is failing.
-- No merge to `main` until all required workflows are green.
+- No merge to `development` or `main` until all required workflows are green.
 - No release from any branch except `main`.
-- No stale branch should be sent for final review without syncing from latest `main`.
+- No stale team branch should be sent for final review without syncing from latest `development`.
 
 ## Frontend Rule
 
@@ -147,3 +156,8 @@ The merge/release decision belongs to Justine after:
 - release-readiness success
 
 Release automation, tags, and release notes belong to `main` only.
+
+Normal promotion path:
+
+- ownership branch -> `development`
+- validated `development` -> `main`

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -119,8 +119,8 @@ After rebasing or syncing from `development`, rerun the relevant checks before r
 
 The frontend is split into two lanes:
 
-- Edward: transactional UI
-- John: observability and presentation UI
+- John: transactional UI
+- Edward: observability and presentation UI
 
 They must not silently co-own the same screen by default.
 

--- a/docs/adr/ADR-0001-justine-scope-documents.md
+++ b/docs/adr/ADR-0001-justine-scope-documents.md
@@ -73,7 +73,7 @@ They do not authorize:
 
 ### 4. Escalation rule
 
-If Edward, Sherwin, or any AI tool cannot point to a valid Justine scope document for a risky change, the correct action is:
+If John, Edward, Sherwin, or any AI tool cannot point to a valid Justine scope document for a risky change, the correct action is:
 
 1. stop widening the change
 2. document the ambiguity
@@ -98,7 +98,7 @@ If a decision matters for later contributors, it should be written into one of t
 ### Positive
 
 - the team gets a concrete authorization surface instead of ambiguous “Justine said so” reasoning
-- Edward can audit scope before implementation
+- John and Edward can audit scope before implementation
 - Sherwin can distinguish design context from product authorization
 - AI rule files gain a stable repository reference
 - review conversations become easier to trace later

--- a/docs/adr/ADR-0002-sherwin-ui-wireframe-task.md
+++ b/docs/adr/ADR-0002-sherwin-ui-wireframe-task.md
@@ -10,7 +10,7 @@ Mandate402 needs a durable design-task artifact for Sherwin so the UI/UX scope i
 
 The team already agreed on a linear anti-silo flow:
 
-`Justine (Scope)` -> `Sherwin (Wireframe)` -> `Justine (Review)` -> `Edward (Transactional UI) + John (Observability UI)` -> `Justine (Review & Merge)`
+`Justine (Scope)` -> `Sherwin (Wireframe)` -> `Justine (Review)` -> `John (Transactional UI) + Edward (Observability UI)` -> `Justine (Review & Merge)`
 
 The missing piece is a tracked task-level ADR that captures:
 
@@ -19,7 +19,7 @@ The missing piece is a tracked task-level ADR that captures:
 - the visual language and operating constraints
 - the exact handoff package the frontend implementation lanes should implement from
 
-Without this, the wireframe task can drift into generic UI exploration, incomplete mobile treatment, or ambiguous design intent that Edward has to reinterpret later.
+Without this, the wireframe task can drift into generic UI exploration, incomplete mobile treatment, or ambiguous design intent that John has to reinterpret later.
 
 ## Decision
 
@@ -35,7 +35,7 @@ Sherwin is responsible for producing the wireframe and interaction-intent packag
 4. agent view
 5. mobile-friendly simplified layout
 
-The task is to turn these product surfaces into a coherent, high-trust control-plane design that Edward can implement without having to invent layout logic or visual hierarchy from scratch.
+The task is to turn these product surfaces into a coherent, high-trust control-plane design that John can implement without having to invent layout logic or visual hierarchy from scratch.
 
 ## Deliverables
 
@@ -48,7 +48,7 @@ Sherwin's expected output includes:
 - button, table, card, and status treatment guidance
 - notes for any interaction behavior that is not obvious from static layouts
 
-The output must be implementable by Edward and John with minimal reinterpretation inside their separate lanes.
+The output must be implementable by John and Edward with minimal reinterpretation inside their separate lanes.
 
 ## In-Scope Screens
 
@@ -58,7 +58,7 @@ Rules for use:
 
 - preserve the information hierarchy and relative grouping shown below
 - treat each block as a monospace wireframe reference, not prose
-- keep Edward's implementation aligned to these structures unless Justine approves a scope change
+- keep John's transactional implementation aligned to these structures unless Justine approves a scope change
 - if Sherwin improves the presentation, the underlying layout intent should still map back to these blocks
 
 ### 1. Main Dashboard
@@ -310,7 +310,7 @@ Sherwin is designing wireframes, not backend logic, but the wireframes must refl
 - agent actions are constrained by mandate boundaries
 - blocked vs successful outcomes must be visually distinct
 
-The wireframes should help Edward and John preserve those product truths during implementation.
+The wireframes should help John and Edward preserve those product truths during implementation.
 
 ## Explicit Non-Goals
 
@@ -336,8 +336,8 @@ Sherwin's handoff package should include:
 
 Frontend implementation responsibility begins after that handoff:
 
-1. Edward audits and implements the transactional UI lane
-2. John implements the observability and presentation lane
+1. John audits and implements the transactional UI lane
+2. Edward implements the observability and presentation lane
 3. both map the wireframe to the current architecture
 4. both surface architectural or shared-surface conflicts before widening scope
 
@@ -347,7 +347,7 @@ This ADR is satisfied when:
 
 1. Sherwin can produce a complete wireframe package from this brief alone
 2. Justine can review the package against product and technical fit
-3. Edward and John can implement from the package without inventing missing layout structure
+3. John and Edward can implement from the package without inventing missing layout structure
 4. desktop and mobile intent are both covered
 5. the design remains consistent with Mandate402's high-trust treasury-control identity
 
@@ -356,7 +356,7 @@ This ADR is satisfied when:
 ### Positive
 
 - Sherwin has a stable, repo-tracked task brief
-- Edward and John receive a clearer implementation handoff
+- John and Edward receive a clearer implementation handoff
 - Justine's design review is grounded in a durable artifact
 - the team reduces silo and tunnel-vision risk during UI work
 

--- a/docs/adr/ADR-0003-john-frontend-implementation-task.md
+++ b/docs/adr/ADR-0003-john-frontend-implementation-task.md
@@ -1,12 +1,12 @@
-# ADR-0003: Edward Transactional Frontend Implementation Boundary
+# ADR-0003: John Transactional Frontend Implementation Boundary
 
 - Status: Accepted
 - Date: 2026-05-16
-- Owners: Justine (`@JustineDevs`), Edward Joseph (`@automatewithedward`)
+- Owners: Justine (`@JustineDevs`), John Abrahm (`@bam841`)
 
 ## Context
 
-The team has a documented design lane for Sherwin, but implementation can still drift if Edward does not have an equally explicit boundary for:
+The team has a documented design lane for Sherwin, but implementation can still drift if John does not have an equally explicit boundary for:
 
 - what "repo audit first" means
 - which files are normally in his lane
@@ -17,11 +17,11 @@ Without this, frontend work can easily widen into backend, infra, or product-red
 
 ## Decision
 
-Edward's frontend work will follow a repo-audit-first implementation model with explicit default ownership, escalation rules, and handoff expectations for the transactional UI lane.
+John's frontend work will follow a repo-audit-first implementation model with explicit default ownership, escalation rules, and handoff expectations for the transactional UI lane.
 
-## Edward Task Definition
+## John Task Definition
 
-Edward is responsible for converting approved design handoffs into working transactional frontend code while preserving the existing runtime and API semantics.
+John is responsible for converting approved design handoffs into working transactional frontend code while preserving the existing runtime and API semantics.
 
 This includes:
 
@@ -33,7 +33,7 @@ This includes:
 
 ## Required Intake Checklist
 
-Before implementation, Edward should:
+Before implementation, John should:
 
 1. sync the latest repository state
 2. review the active scope source from Justine
@@ -45,25 +45,25 @@ If a conflict is found, it should be written down and escalated before large imp
 
 ## Default File Ownership
 
-Unless Justine scope documents explicitly widen the task, Edward's default implementation lane is:
+Unless Justine scope documents explicitly widen the task, John's default implementation lane is:
 
 - `src/components/**`
 - `src/app/**` where work touches mandate creation, attempts, revoke, or auth-aware flows
 - shared frontend styling surfaces only when a transactional lane change requires them
 - `public/**` for UI assets needed for implementation
 
-Edward may update these areas to complete frontend work, but should not silently widen into:
+John may update these areas to complete frontend work, but should not silently widen into:
 
 - infrastructure or workflow files
 - backend semantics
 - contract logic
 - release tooling
 - changes that redefine the product model itself
-- presentation-heavy screens already owned by John unless coordination is explicit
+- presentation-heavy screens already owned by Edward unless coordination is explicit
 
 ## What Sherwin's Handoff Authorizes
 
-Sherwin's design handoff authorizes Edward to implement:
+Sherwin's design handoff authorizes John to implement:
 
 - layout structure for transactional surfaces
 - spacing and hierarchy
@@ -71,7 +71,7 @@ Sherwin's design handoff authorizes Edward to implement:
 - responsive behavior
 - status badges and presentation logic
 
-It does not by itself authorize Edward to redefine:
+It does not by itself authorize John to redefine:
 
 - policy rules
 - backend validation rules
@@ -83,7 +83,7 @@ Those require scope authority from Justine as defined in [ADR-0001](./ADR-0001-j
 
 ## Escalation Triggers
 
-Edward must escalate instead of improvising when:
+John must escalate instead of improvising when:
 
 - the UI requires backend data the current API does not provide
 - the design implies a product rule not present in the scope documents
@@ -95,7 +95,7 @@ The goal is not to block progress; the goal is to keep product truth visible.
 
 ## Expected Output
 
-Edward's implementation handoff should include:
+John's implementation handoff should include:
 
 - working transactional frontend changes
 - short repo-audit notes if a conflict was found
@@ -107,7 +107,7 @@ Edward's implementation handoff should include:
 
 This ADR is satisfied when:
 
-1. Edward can implement transactional frontend work without having to guess his authority boundary
+1. John can implement transactional frontend work without having to guess his authority boundary
 2. Sherwin's design handoff can be translated into code without redefining backend semantics
 3. Justine can review the output knowing where frontend authority ended and escalation began
 
@@ -122,5 +122,5 @@ This ADR is satisfied when:
 
 ### Tradeoffs
 
-- Edward may need to pause sooner on ambiguous work
+- John may need to pause sooner on ambiguous work
 - some "quick fixes" become explicit scope conversations instead of silent implementation choices

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -8,7 +8,7 @@ This document is for contributors who need to know which architecture or workflo
 |---|---|---|---|
 | [ADR-0001](./ADR-0001-justine-scope-documents.md) | Justine Scope Documents as the Explicit Authorization Surface | Accepted | Defines what counts as explicit scope authority for Justine-led work |
 | [ADR-0002](./ADR-0002-sherwin-ui-wireframe-task.md) | Sherwin UI Wireframe Task for Mandate402 Operator Surfaces | Accepted | Defines the canonical wireframe, palette, and design handoff for Sherwin |
-| [ADR-0003](./ADR-0003-edward-frontend-implementation-task.md) | Edward Frontend Implementation Task and Repo Audit Boundary | Accepted | Defines Edward's transactional frontend lane and escalation boundaries |
+| [ADR-0003](./ADR-0003-john-frontend-implementation-task.md) | John Frontend Implementation Task and Repo Audit Boundary | Accepted | Defines John's transactional frontend lane and escalation boundaries |
 
 ## How To Use ADRs
 
@@ -20,4 +20,4 @@ This document is for contributors who need to know which architecture or workflo
 
 - Justine scope authority: [ADR-0001](./ADR-0001-justine-scope-documents.md)
 - Sherwin design task: [ADR-0002](./ADR-0002-sherwin-ui-wireframe-task.md)
-- Edward transactional implementation task: [ADR-0003](./ADR-0003-edward-frontend-implementation-task.md)
+- John transactional implementation task: [ADR-0003](./ADR-0003-john-frontend-implementation-task.md)


### PR DESCRIPTION
## Problem
The repository needed a stable integration branch for team work. Using `main` or stale topic branches as ad hoc integration points was allowing branch drift, mixed-history PRs, and non-reviewable diffs like PR #14.

Closes #16.

## What Changed
- seeded a remote `development` branch from current `main`
- documented `development` as the protected integration branch and `main` as the only release-authoritative branch
- changed contributor sync guidance to rebase ownership branches on `origin/development`
- updated CI to run on pushes to `development`
- added a workflow to sync `main` into `development`

## Verification
- `git diff --check`
- verified remote `development` branch creation from current `main`

## Deployment / Credentials
No credential changes. Branch protection settings for `development` still need to be aligned in GitHub settings after merge so the sync workflow has the intended permissions model.

## Remaining Blockers
- The sync workflow becomes active only after this PR lands on `main`.
- If branch protection blocks GitHub Actions from pushing to `development`, the repo settings need a maintainer adjustment.

## Owner Lane
Justine / repository workflow and release process.

## AI Usage
AI-assisted branch-model, workflow, and review-process update.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/justinedevs/mandate402/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->