### PR TITLE
Land remaining release and sync refinements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: production
     permissions:
       contents: write
       issues: write
@@ -15,6 +16,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN || github.token }}
       - uses: pnpm/action-setup@v4
         with:
           version: 10.20.0
@@ -25,4 +27,4 @@ jobs:
       - run: pnpm install --frozen-lockfile=false
       - run: pnpm release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}

--- a/.github/workflows/sync-development.yml
+++ b/.github/workflows/sync-development.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN || github.token }}
 
       - name: Configure git
         run: |
@@ -43,7 +44,7 @@ jobs:
           git switch -c development-sync origin/development
           before_sha="$(git rev-parse HEAD)"
 
-          if ! git merge --no-edit origin/main; then
+          if ! git merge origin/main --no-ff -m "chore(sync): align development with main release state [skip ci]"; then
             echo "::error::Automatic sync from main into development hit a merge conflict. Resolve it manually before the branch drifts further."
             exit 1
           fi

--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -12,7 +12,7 @@ This document defines the required Git branching model for Mandate402.
 
 Normal path:
 
-`main` -> auto-sync into `development` -> ownership branch -> PR into `development` -> promotion PR from `development` into `main`
+`ownership branch` -> `PR into development` -> `promotion PR from development into main` -> `semantic-release on main` -> `auto-sync main back into development`
 
 ## Branch Naming
 

--- a/docs/RELEASE-POLICY.md
+++ b/docs/RELEASE-POLICY.md
@@ -18,9 +18,11 @@ Release automation is owned by CI on `main`.
 
 That means:
 
+- `main` is the production source-of-truth branch
 - tags are created automatically from `main`
 - release notes are created automatically from `main`
 - humans do not manually tag releases under normal operation
+- the release workflow uses `semantic-release` on every eligible push to `main`
 
 ## Merge-to-Release Rule
 
@@ -37,6 +39,18 @@ Hotfix exception:
 
 - urgent maintainer-approved hotfixes may branch from `main` and return directly to `main`
 - after a hotfix lands, `development` must be resynced from `main`
+
+## Main-To-Development Sync Rule
+
+After `main` changes, the repository sync workflow should merge the new release-authoritative state back into `development`.
+
+Expected behavior:
+
+- sync commit lands on `development`
+- sync commit uses `[skip ci]` because it is automation-only branch alignment work
+- the sync workflow explicitly dispatches the required `CI` and `API Smoke` workflows on `development`
+
+This keeps `development` aligned to released history without depending on duplicate push-triggered workflow runs.
 
 ## Required Conditions Before Merge To `main`
 


### PR DESCRIPTION
## Problem
PR #17 merged the main development-branch model, but four release/sync refinements remained only on the old `chore/development-branch-model` branch. Leaving them there keeps a redundant remote branch alive and leaves the release/sync contract incomplete on `main`.

Closes #18.

## What Changed
- carried over only the 4 remaining files from `chore/development-branch-model`
- kept `semantic-release` on `main` as the production release path
- aligned release/sync workflows to the `GH_TOKEN` convention
- made the sync-back merge into `development` use an explicit `[skip ci]` message
- clarified the `main -> release -> sync back to development` branch model in docs

## Verification
- `git diff --check`
- verified this branch is limited to 4 files only

## Deployment / Credentials
This still assumes repository Actions are allowed to write and that `GH_TOKEN` is configured when the default token is insufficient for protected-branch or dispatch behavior.

## Remaining Blockers
None for branch cleanup after this PR exists. The old remote process branch can be deleted because its remaining changes are now preserved here.

## Owner Lane
Justine / repository workflow and release process.

## AI Usage
AI-assisted rescue PR extraction from the superseded process branch.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/justinedevs/mandate402/pull/19" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->