### PR TITLE
Skip deploy-adjacent work for docs-only changes

### DIFF
--- a/.github/workflows/api-smoke.yml
+++ b/.github/workflows/api-smoke.yml
@@ -7,7 +7,25 @@ on:
   workflow_dispatch:
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      smoke: ${{ steps.scope.outputs.smoke }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: scope
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_BEFORE: ${{ github.event.before }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: bash scripts/ci/change-scope.sh github
+
   smoke:
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.smoke == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,27 @@ on:
   workflow_dispatch:
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.scope.outputs.app }}
+      go: ${{ steps.scope.outputs.go }}
+      contracts: ${{ steps.scope.outputs.contracts }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: scope
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_BEFORE: ${{ github.event.before }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: bash scripts/ci/change-scope.sh github
+
   app:
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,6 +47,8 @@ jobs:
       - run: pnpm build
 
   contracts:
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.contracts == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,6 +58,8 @@ jobs:
       - run: cd contracts && FOUNDRY_CACHE_PATH=cache FOUNDRY_OUT=out forge test
 
   go:
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/scripts/ci/change-scope.sh
+++ b/scripts/ci/change-scope.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${1:-}"
+
+matches_app() {
+  case "$1" in
+    src/app/*|src/components/*|src/lib/*|public/*|package.json|pnpm-lock.yaml|tsconfig.json|next.config.*|eslint.config.*|biome.json|vercel.json|scripts/ci/change-scope.sh)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+matches_go() {
+  case "$1" in
+    main.go|go.mod|go.sum)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+matches_contracts() {
+  case "$1" in
+    contracts/*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+list_files_from_head_commit() {
+  git show --format= --name-only --first-parent HEAD | sed '/^$/d'
+}
+
+list_files_for_github_event() {
+  case "${GITHUB_EVENT_NAME:-}" in
+    pull_request)
+      git fetch --no-tags origin "${GITHUB_BASE_REF:?}" --depth=1 >/dev/null 2>&1 || true
+      if ! git diff --name-only "origin/${GITHUB_BASE_REF}...${GITHUB_HEAD_SHA:?}"; then
+        list_files_from_head_commit
+      fi
+      ;;
+    push)
+      if [[ -z "${GITHUB_BEFORE:-}" || "${GITHUB_BEFORE}" =~ ^0+$ ]]; then
+        list_files_from_head_commit
+      elif ! git diff --name-only "${GITHUB_BEFORE}" "${GITHUB_SHA:?}"; then
+        list_files_from_head_commit
+      fi
+      ;;
+    *)
+      list_files_from_head_commit
+      ;;
+  esac
+}
+
+classify_files() {
+  local app=false
+  local go=false
+  local contracts=false
+  local smoke=false
+
+  while IFS= read -r file; do
+    [[ -z "$file" ]] && continue
+
+    if matches_app "$file"; then
+      app=true
+      smoke=true
+    fi
+
+    if matches_go "$file"; then
+      go=true
+      smoke=true
+    fi
+
+    if matches_contracts "$file"; then
+      contracts=true
+    fi
+  done
+
+  printf 'app=%s\n' "$app"
+  printf 'go=%s\n' "$go"
+  printf 'contracts=%s\n' "$contracts"
+  printf 'smoke=%s\n' "$smoke"
+}
+
+case "$mode" in
+  vercel-ignore)
+    changed_files="$(list_files_from_head_commit)"
+    should_deploy=false
+    while IFS= read -r file; do
+      [[ -z "$file" ]] && continue
+      if matches_app "$file"; then
+        should_deploy=true
+        break
+      fi
+    done <<<"$changed_files"
+
+    if [[ "$should_deploy" == "false" ]]; then
+      echo "No app-affecting changes detected. Skip Vercel build."
+      exit 0
+    fi
+
+    echo "App-affecting changes detected. Continue Vercel build."
+    exit 1
+    ;;
+  github)
+    changed_files="$(list_files_for_github_event)"
+    echo "Changed files:"
+    printf '%s\n' "$changed_files" | sed '/^$/d; s/^/- /'
+    classify_files <<<"$changed_files" >> "${GITHUB_OUTPUT:?}"
+    ;;
+  *)
+    echo "Unsupported mode: $mode" >&2
+    exit 2
+    ;;
+esac

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "bash scripts/ci/change-scope.sh vercel-ignore"
+}


### PR DESCRIPTION
## Problem
Docs-only and non-runtime changes still trigger deploy-adjacent work today, especially Vercel Git builds and heavier runtime verification jobs. That wastes build time and creates unnecessary preview/prod churn when the deployed app surface did not actually change.

Closes #21.

## What Changed
- added a shared `scripts/ci/change-scope.sh` classifier for runtime-impacting file changes
- gated `CI` app/go/contracts jobs behind changed runtime scope
- gated `API Smoke` behind changed app/go scope
- added `vercel.json` with `ignoreCommand` so Vercel skips builds when the commit does not touch app-affecting files

## Why This Shape
- job-level gating keeps required checks present on triggered workflows
- workflow-level `paths-ignore` would hide checks entirely on docs-only changes and is less compatible with protected-branch expectations
- Vercel Git deployments are outside GitHub Actions, so the repo needs a Vercel-native skip mechanism too

## Verification
- `git diff --check`
- `bash scripts/ci/change-scope.sh vercel-ignore`
- `pnpm check:biome`
- local pre-push suite passed:
  - release-readiness
  - repo-safety
  - biome
  - test
  - typecheck
  - contracts
  - go

## Deployment / Credentials
No credential changes. Vercel skip behavior depends on the `ignoreCommand` feature in the connected Vercel project honoring `vercel.json`.

## Remaining Blockers
- This PR does not create a dedicated worker deploy workflow. It only prevents unnecessary app build/deploy-adjacent work and runtime verification when the changed files are docs/process-only.

## Owner Lane
Justine / repository workflow and CI-CD hardening.

## AI Usage
AI-assisted CI/CD gating and Vercel ignore-step implementation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/justinedevs/mandate402/pull/22" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->