### PR TITLE
fix(ci): correct GitHub API for PR assignees in routing workflow

### DIFF
--- a/.github/workflows/pr-routing.yml
+++ b/.github/workflows/pr-routing.yml
@@ -59,7 +59,7 @@ jobs:
               });
             }
 
-            await github.rest.issues.setAssignees({
+            await github.rest.issues.addAssignees({
               owner,
               repo,
               issue_number: pull_number,


### PR DESCRIPTION
## Summary

`pull_request_target` always runs `pr-routing.yml` from `main`. The workflow called `github.rest.issues.setAssignees`, which is not a valid Octokit method, so `route-pr` failed on every PR with a TypeError.

## Test plan

- [ ] After merge, open or synchronize any PR and confirm the `route-pr` check succeeds.


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/justinedevs/mandate402/pull/36" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->