### PR TITLE
chore(workers): add analytics and KV bindings to wrangler config

### DIFF
--- a/wrangler.worker.toml
+++ b/wrangler.worker.toml
@@ -3,11 +3,23 @@ main = "src/workers/mandate402.ts"
 compatibility_date = "2025-05-21"
 compatibility_flags = ["nodejs_compat"]
 
+[observability]
+enabled = true
+
 [vars]
 MANDATE402_CONTROL_API_URL = "https://your-app.example.com"
 
 [triggers]
 crons = ["*/5 * * * *"]
+
+[[analytics_engine_datasets]]
+binding = "ANALYTICS_ENGINE"
+dataset = "analytics_event"
+
+[[kv_namespaces]]
+binding = "KV"
+id = "44968c7208a44ae8aae5acabb04c6c11"
+preview_id = "<ID_OF_PREVIEW_KV_NAMESPACE_FOR_LOCAL_DEVELOPMENT>"
 
 [[queues.producers]]
 binding = "EXECUTION_QUEUE"


### PR DESCRIPTION
## Summary

- add `observability.enabled = true` to `wrangler.worker.toml`
- add `analytics_engine_datasets` binding `ANALYTICS_ENGINE -> analytics_event`
- add `kv_namespaces` binding `KV -> 44968c7208a44ae8aae5acabb04c6c11`
- add `preview_id` placeholder for local `wrangler dev`

## Scope

This PR intentionally changes only `wrangler.worker.toml`.

## Verification

- reviewed clean diff against `origin/main`
- confirmed the PR branch contains only the requested `wrangler.worker.toml` additions

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/justinedevs/mandate402/pull/38" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->